### PR TITLE
chore: format

### DIFF
--- a/template_analysis/analyzer.py
+++ b/template_analysis/analyzer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import difflib
 from dataclasses import dataclass
-from typing import Union
 
 from .symbol import (
     Chunks,
@@ -52,7 +51,7 @@ class Analyzer:
     table: SymbolTable
 
     @classmethod
-    def create(cls, text: Union[str, SymbolString]) -> Analyzer:
+    def create(cls, text: str | SymbolString) -> Analyzer:
         return cls(
             list(text),
             pos=0,


### PR DESCRIPTION
`from __future__ import annotations` makes `A | B` interpreted as `Union[A, B]`,
so `Union[A, B]` is converted to `A | B` by format.
