### PR TITLE
Support Python 3.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Intended Audience :: Developers
     Topic :: Software Development :: Libraries
 


### PR DESCRIPTION
Python 3.11 is already confirmed to work in CI.
Add Python 3.11 to PyPI classifiers.
