### PR TITLE
Tighten Ruff lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,40 @@ ignore_missing_imports = false
 
 [tool.ruff]
 line-length = 79
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "COM",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"template_analysis/analyzer.py" = [
+    "S101",
+]
+"template_analysis/symbol.py" = [
+    "S101",
+]
+"tests/**/*.py" = [
+    "ANN",
+    "D",
+    "S101",
+]

--- a/template_analysis/__init__.py
+++ b/template_analysis/__init__.py
@@ -4,15 +4,13 @@ This library does the opposite of template engines.
 Template engines take a template and data, and return a formatted string.
 This library takes a formatted string and returns a template and data."""
 
-from .analyzer import Analyzer, AnalyzerResult, analyze  # noqa: F401
-
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
 from ._version import __version__
-
+from .analyzer import Analyzer, AnalyzerResult, analyze
 
 __all__ = [
     "Analyzer",
     "AnalyzerResult",
-    "analyze",
     "__version__",
+    "analyze",
 ]

--- a/template_analysis/analyzer.py
+++ b/template_analysis/analyzer.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import difflib
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Iterator
 
 from .symbol import (
     Chunks,
@@ -25,7 +25,7 @@ class AnalyzerResult:
     @property
     def template(self) -> Template:
         return Template.from_symbol_template(
-            SymbolTemplate(self.text[:], SymbolTable.create())
+            SymbolTemplate(self.text[:], SymbolTable.create()),
         )
 
     @property
@@ -102,7 +102,7 @@ class Analyzer:
 
     @classmethod
     def analyze_two_symbol_strings(
-        cls, seq1: SymbolString, seq2: SymbolString
+        cls, seq1: SymbolString, seq2: SymbolString,
     ) -> tuple[Analyzer, Analyzer]:
         matcher = difflib.SequenceMatcher(None, seq1, seq2)
         blocks = matcher.get_matching_blocks()
@@ -122,10 +122,10 @@ class Analyzer:
 
     @classmethod
     def analyze_two_result(
-        cls, result1: AnalyzerResult, result2: AnalyzerResult
+        cls, result1: AnalyzerResult, result2: AnalyzerResult,
     ) -> AnalyzerResult:
         analyzer_a, analyzer_b = cls.analyze_two_symbol_strings(
-            result1.text, result2.text
+            result1.text, result2.text,
         )
         assert analyzer_a.parsed_text == analyzer_b.parsed_text
         return AnalyzerResult(

--- a/template_analysis/symbol.py
+++ b/template_analysis/symbol.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
 
 Character = str
 Chunk = str
@@ -43,8 +42,8 @@ class SymbolTable:
         return SymbolTable(new_table)
 
 
-SymbolOrCharacter = Union[Symbol, Character]
-SymbolChunk = Union[Symbol, Chunk]
+SymbolOrCharacter = Symbol | Character
+SymbolChunk = Symbol | Chunk
 Chunks = list[Chunk]
 SymbolString = list[SymbolOrCharacter]
 SymbolChunks = list[SymbolChunk]

--- a/template_analysis/template.py
+++ b/template_analysis/template.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
 
 from .symbol import Symbol, SymbolTemplate
 
@@ -27,7 +26,7 @@ class PlainText:
 
 
 # A part of a template is either a plain text chunk or a variable.
-TemplatePart = Union[PlainText, Variable]
+TemplatePart = PlainText | Variable
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

Tighten the Ruff lint configuration with a stricter, low-friction rule set.

## Changes

- enable a broader set of non-framework-specific Ruff rules
- keep test files practical with targeted per-file ignores where needed
- update code that was auto-fixable or low-cost to adjust manually

## Verification

- `uv run poe check`
- `uv run poe test`
