### PR TITLE
Tighten Ruff McCabe complexity limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,6 @@ select = [
     "D",
     "S101",
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,4 +109,4 @@ select = [
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 5
+max-complexity = 3

--- a/template_analysis/analyzer.py
+++ b/template_analysis/analyzer.py
@@ -17,6 +17,12 @@ from .symbol import (
 from .template import Template
 
 
+def chunk_to_symbol_string(chunk: SymbolChunk) -> SymbolString:
+    if isinstance(chunk, Symbol):
+        return [chunk]
+    return list(chunk)
+
+
 @dataclass(frozen=True)
 class AnalyzerResult:
     text: SymbolString
@@ -66,14 +72,11 @@ class Analyzer:
 
     @property
     def parsed_text(self) -> SymbolString:
-        chunks: SymbolString = []
-        for chunk in self.parsed:
-            if isinstance(chunk, Symbol):
-                chunks.append(chunk)
-            else:
-                for char in chunk:
-                    chunks.append(char)
-        return chunks
+        return [
+            symbol_or_character
+            for chunk in self.parsed
+            for symbol_or_character in chunk_to_symbol_string(chunk)
+        ]
 
     def __read_n_tokens(self, size: int) -> Iterator[SymbolChunk]:
         start = self.pos

--- a/template_analysis/symbol.py
+++ b/template_analysis/symbol.py
@@ -49,22 +49,25 @@ SymbolString = list[SymbolOrCharacter]
 SymbolChunks = list[SymbolChunk]
 
 
+def append_chunk(symbol_chunks: SymbolChunks, chunk: Chunk) -> Chunk:
+    if chunk:
+        symbol_chunks.append(chunk)
+    return ""
+
+
 def to_symbol_chunks(
     symbol_string: SymbolString,
 ) -> SymbolChunks:
-    x: SymbolChunks = []
+    symbol_chunks: SymbolChunks = []
     chunk: str = ""
     for symbol_or_character in symbol_string:
         if isinstance(symbol_or_character, Symbol):
-            if chunk:
-                x.append(chunk)
-                chunk = ""
-            x.append(symbol_or_character)
-        else:
-            chunk += symbol_or_character
-    if chunk:
-        x.append(chunk)
-    return x
+            chunk = append_chunk(symbol_chunks, chunk)
+            symbol_chunks.append(symbol_or_character)
+            continue
+        chunk += symbol_or_character
+    append_chunk(symbol_chunks, chunk)
+    return symbol_chunks
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- add Ruff McCabe `max-complexity = 5`
- lower the limit to `3`
- extract chunk flattening and chunk appending helpers to keep the analyzer logic readable

## Testing
- `uv run poe check`
- `uv run poe test`

## Notes
- `uv run poe build` currently fails because `build` is not installed in the project environment