### PR TITLE
Fix project metadata name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "throttle-controller"
+name = "template-analysis"
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-04-12T02:07:08.72517967Z"
+exclude-newer = "2026-04-25T14:59:07.319861Z"
 exclude-newer-span = "P2D"
 
 [[package]]
@@ -498,7 +498,7 @@ wheels = [
 ]
 
 [[package]]
-name = "throttle-controller"
+name = "template-analysis"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Change the Python project metadata name from `throttle-controller` to `template-analysis`.
- Refresh `uv.lock` so the editable package entry matches the project metadata.

## Verification
- uv lock
- uv run poe check
- uv run poe test
- git diff --check
