### PR TITLE
Use reusable GitHub Actions workflows

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -1,16 +1,11 @@
 name: Update gitignore file
-
 on:
   schedule:
     # daily at 00:00
     - cron: '0 0 * * *'
-
 permissions:
   contents: write
   pull-requests: write
-
 jobs:
   update-gitignore:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: gitignore-in/gh-action@v0.2.3
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -1,18 +1,10 @@
 name: happy-commit
 on:
   - pull_request
-
 permissions:
   contents: read
   pull-requests: write
   issues: write
-
 jobs:
   happy:
-    runs-on: ubuntu-latest
-    name: happy
-    continue-on-error: true
-    steps:
-      - uses: kitsuyui/happy-commit@v0.9
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,12 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Check spelling
-        uses: crate-ci/typos@master
-        # typos is a Source code spell checker
-        # https://github.com/crate-ci/typos
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main


### PR DESCRIPTION
## Summary

- Replace duplicate workflow bodies with thin callers to `kitsuyui/gh-actions-workflows`.
- Keep repository-local triggers and permissions in the caller workflow files.

## Changed files

- `.github/workflows/gitignore-in.yml`
- `.github/workflows/happy.yml`
- `.github/workflows/spellcheck.yml`

## Validation

- `actionlint -color=false` was run against the rewritten workflow files from the hub workspace.
- `git diff --check` passed for this repository before commit.
