### PR TITLE
Pin reusable workflow refs

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: write
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@0b691527a4dde052c79eae22706131a7726a2bba # main

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -7,4 +7,4 @@ permissions:
   issues: write
 jobs:
   happy:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@0b691527a4dde052c79eae22706131a7726a2bba # main

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   actionlint:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@0b691527a4dde052c79eae22706131a7726a2bba # main
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@0b691527a4dde052c79eae22706131a7726a2bba # main


### PR DESCRIPTION
## Summary
- Pin reusable workflow refs from `kitsuyui/gh-actions-workflows` to a full commit SHA.
- Keep the previous `main` ref as inline comments for update context.

## Verification
- `actionlint .github/workflows/python-test.yml .github/workflows/spellcheck.yml .github/workflows/happy.yml .github/workflows/gitignore-in.yml`
- `git diff --check`
- Verified the pinned SHA through the GitHub API.
