### PR TITLE
Pin test workflow actions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -23,16 +23,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python }}"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

- Pin `actions/checkout`, `actions/setup-python`, and `astral-sh/setup-uv` in `.github/workflows/python-test.yml` to immutable commit SHAs (with version comment).
- Same SHAs already in use in `.github/workflows/pypi-publish.yml` (#359).

## Test plan

- [ ] CI green (`actionlint`, matrix `test`)