### PR TITLE
Add workflow concurrency controls

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,6 +7,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
- Add workflow-level concurrency groups to the octocov, packaging, and test workflows.
- Cancel superseded runs for the same workflow/ref so only the latest branch update continues.
- Keep release publishing runs from being canceled while still canceling superseded packaging PR runs.

## Validation
- `actionlint`
- `git diff --check`
- `uv sync`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`

## Trade-offs
- Concurrency is scoped by workflow/ref. A new commit on the same branch cancels older runs for that workflow, but release publishing runs are allowed to finish.
