### PR TITLE
refactor: replace assert with explicit RuntimeError in production invariant checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,12 +96,6 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"template_analysis/analyzer.py" = [
-    "S101",
-]
-"template_analysis/symbol.py" = [
-    "S101",
-]
 "tests/**/*.py" = [
     "ANN",
     "D",

--- a/template_analysis/analyzer.py
+++ b/template_analysis/analyzer.py
@@ -105,7 +105,9 @@ class Analyzer:
 
     @classmethod
     def analyze_two_symbol_strings(
-        cls, seq1: SymbolString, seq2: SymbolString,
+        cls,
+        seq1: SymbolString,
+        seq2: SymbolString,
     ) -> tuple[Analyzer, Analyzer]:
         matcher = difflib.SequenceMatcher(None, seq1, seq2)
         blocks = matcher.get_matching_blocks()
@@ -125,12 +127,21 @@ class Analyzer:
 
     @classmethod
     def analyze_two_result(
-        cls, result1: AnalyzerResult, result2: AnalyzerResult,
+        cls,
+        result1: AnalyzerResult,
+        result2: AnalyzerResult,
     ) -> AnalyzerResult:
         analyzer_a, analyzer_b = cls.analyze_two_symbol_strings(
-            result1.text, result2.text,
+            result1.text,
+            result2.text,
         )
-        assert analyzer_a.parsed_text == analyzer_b.parsed_text
+        if analyzer_a.parsed_text != analyzer_b.parsed_text:
+            raise RuntimeError(
+                "Internal invariant violated: both analyzers must produce "
+                "the same parsed_text. This indicates a bug in the analysis "
+                f"algorithm. Got: {analyzer_a.parsed_text!r} vs "
+                f"{analyzer_b.parsed_text!r}",
+            )
         return AnalyzerResult(
             analyzer_a.parsed_text,
             [

--- a/template_analysis/symbol.py
+++ b/template_analysis/symbol.py
@@ -33,7 +33,12 @@ class SymbolTable:
     def lookup(self, symbol_or_chunk: SymbolChunk) -> Chunk:
         while isinstance(symbol_or_chunk, Symbol):
             symbol_or_chunk = self.table[symbol_or_chunk]
-        assert isinstance(symbol_or_chunk, Chunk)
+        if not isinstance(symbol_or_chunk, Chunk):
+            raise RuntimeError(
+                f"Internal invariant violated: expected Chunk after symbol "
+                f"resolution but got {type(symbol_or_chunk).__name__!r}. "
+                "This indicates an unresolvable symbol or a cycle.",
+            )
         return symbol_or_chunk
 
     def combined(self, other: SymbolTable) -> SymbolTable:


### PR DESCRIPTION
## Summary

Production code in `template_analysis/analyzer.py` and `template_analysis/symbol.py`
used `assert` statements to enforce runtime invariants. Python's `-O` (optimize) flag
removes all assert statements at startup, silently disabling these checks and allowing
corrupted state to propagate undetected.

### Changes

- **`template_analysis/analyzer.py`**: Replace `assert analyzer_a.parsed_text == analyzer_b.parsed_text`
  with an explicit `RuntimeError` that includes a descriptive message and the differing values.
- **`template_analysis/symbol.py`**: Replace `assert isinstance(symbol_or_chunk, Chunk)`
  with an explicit `RuntimeError` that names the unexpected type.
- **`pyproject.toml`**: Remove the `S101` (assert usage) suppression for both source files.
  The `assert` statements are now gone, so CI will catch any future regressions.

### Verification

- `ruff check`: all checks passed
- `mypy`: no issues found in 5 source files
- `pytest`: 11 passed in 0.02s