### PR TITLE
fix: support empty template variable slots

### DIFF
--- a/template_analysis/analyzer.py
+++ b/template_analysis/analyzer.py
@@ -98,14 +98,30 @@ class Analyzer:
             self.parsed.append(symbol)
             self.table.add(symbol, s)
 
-    def advance(self, pos: int, size: int, symbol: Symbol) -> None:
-        while (unmatch_length := pos - self.pos) > 0:
-            self.append_unique(unmatch_length, symbol)
+    def append_unique_or_empty(self, size: int, symbol: Symbol) -> None:
+        if size == 0:
+            self.parsed.append(symbol)
+            self.table.add(symbol, "")
+            return
+        self.append_unique(size, symbol)
+
+    def advance(
+        self,
+        pos: int,
+        size: int,
+        symbol: Symbol,
+        force_unique: bool = False,
+    ) -> None:
+        unmatch_length = pos - self.pos
+        if force_unique or unmatch_length > 0:
+            self.append_unique_or_empty(unmatch_length, symbol)
         self.append_match(size)
 
     @classmethod
     def analyze_two_symbol_strings(
-        cls, seq1: SymbolString, seq2: SymbolString,
+        cls,
+        seq1: SymbolString,
+        seq2: SymbolString,
     ) -> tuple[Analyzer, Analyzer]:
         matcher = difflib.SequenceMatcher(None, seq1, seq2)
         blocks = matcher.get_matching_blocks()
@@ -114,8 +130,21 @@ class Analyzer:
 
         for block in blocks:
             symbol = Symbol.create()
-            analyzer_a.advance(block.a, block.size, symbol)
-            analyzer_b.advance(block.b, block.size, symbol)
+            unmatch_a = block.a - analyzer_a.pos
+            unmatch_b = block.b - analyzer_b.pos
+            force_unique = unmatch_a > 0 or unmatch_b > 0
+            analyzer_a.advance(
+                block.a,
+                block.size,
+                symbol,
+                force_unique,
+            )
+            analyzer_b.advance(
+                block.b,
+                block.size,
+                symbol,
+                force_unique,
+            )
 
         return analyzer_a, analyzer_b
 
@@ -125,10 +154,13 @@ class Analyzer:
 
     @classmethod
     def analyze_two_result(
-        cls, result1: AnalyzerResult, result2: AnalyzerResult,
+        cls,
+        result1: AnalyzerResult,
+        result2: AnalyzerResult,
     ) -> AnalyzerResult:
         analyzer_a, analyzer_b = cls.analyze_two_symbol_strings(
-            result1.text, result2.text,
+            result1.text,
+            result2.text,
         )
         assert analyzer_a.parsed_text == analyzer_b.parsed_text
         return AnalyzerResult(

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -28,6 +28,22 @@ def test_analyzer_analyze_2_texts() -> None:
     assert result.args[1] == ["cat"]
 
 
+def test_analyzer_analyze_2_texts_with_empty_variable() -> None:
+    result = analyze(["axb", "ab"])
+
+    assert result.to_format_string() == "a{}b"
+    assert result.args[0] == ["x"]
+    assert result.args[1] == [""]
+
+
+def test_analyzer_analyze_2_texts_with_empty_variable_first() -> None:
+    result = analyze(["ab", "axb"])
+
+    assert result.to_format_string() == "a{}b"
+    assert result.args[0] == [""]
+    assert result.args[1] == ["x"]
+
+
 def test_analyzer_analyze_3_texts() -> None:
     text1 = "A dog is a good pet"
     text2 = "A cat is a good pet"


### PR DESCRIPTION
## Summary
- represent empty unmatched text as a template variable value instead of dropping the slot
- preserve the parsed template shape when only one input has text between two matching regions
- add regression tests for empty variable values in both input orders

## Verification
- `uv sync`
- `uv run pytest tests/test_analyzer.py -q`
- `uv run poe check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `git diff --check`
