### PR TITLE
fix: export AnalyzerResult public return types

### DIFF
--- a/template_analysis/__init__.py
+++ b/template_analysis/__init__.py
@@ -7,10 +7,20 @@ This library takes a formatted string and returns a template and data."""
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
 from ._version import __version__
 from .analyzer import Analyzer, AnalyzerResult, analyze
+from .symbol import Chunks, Symbol, SymbolString, SymbolTable
+from .template import PlainText, Template, TemplatePart, Variable
 
 __all__ = [
     "Analyzer",
     "AnalyzerResult",
+    "Chunks",
+    "PlainText",
+    "Symbol",
+    "SymbolString",
+    "SymbolTable",
+    "Template",
+    "TemplatePart",
+    "Variable",
     "__version__",
     "analyze",
 ]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,41 @@
+import template_analysis
+from template_analysis import (
+    Chunks,
+    PlainText,
+    Symbol,
+    SymbolString,
+    SymbolTable,
+    Template,
+    TemplatePart,
+    Variable,
+)
+
+
+def test_analyzer_result_return_types_are_public() -> None:
+    expected_exports = {
+        "Chunks",
+        "PlainText",
+        "Symbol",
+        "SymbolString",
+        "SymbolTable",
+        "Template",
+        "TemplatePart",
+        "Variable",
+    }
+
+    assert expected_exports <= set(template_analysis.__all__)
+
+
+def test_public_return_type_imports_resolve() -> None:
+    symbol = Symbol.create()
+    symbol_string: SymbolString = [symbol, "x"]
+    chunks: Chunks = ["dog"]
+    table = SymbolTable.create()
+    template = Template([PlainText("A "), Variable(0)])
+    template_part: TemplatePart = PlainText("part")
+
+    assert symbol_string == [symbol, "x"]
+    assert chunks == ["dog"]
+    assert table.lookup("cat") == "cat"
+    assert template.to_format_string() == "A {}"
+    assert template_part.to_format_string() == "part"


### PR DESCRIPTION
## Summary
- export the public types returned or exposed by `AnalyzerResult` from the top-level package
- include template part types so `Template.parts` can be annotated without importing internal modules
- add regression coverage for top-level public API exports

## Verification
- `uv sync`
- `uv run pytest tests/test_public_api.py -q`
- `uv run poe check`
- `uv run ruff check .`
- `uv run ruff format --check template_analysis/__init__.py tests/test_public_api.py`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `git diff --check`
