### PR TITLE
fix: normalize text to NFC in from_text to handle mixed Unicode normalization

### DIFF
--- a/template_analysis/analyzer.py
+++ b/template_analysis/analyzer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import difflib
+import unicodedata
 from collections.abc import Iterator
 from dataclasses import dataclass
 
@@ -46,7 +47,7 @@ class AnalyzerResult:
     @classmethod
     def _from_text(cls, text: str) -> AnalyzerResult:
         return AnalyzerResult(
-            text=list(text),
+            text=list(unicodedata.normalize("NFC", text)),
             tables=[SymbolTable.create()],
         )
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,3 +1,5 @@
+import unicodedata
+
 import pytest
 
 from template_analysis import analyze
@@ -95,3 +97,14 @@ def test_analyzer_to_format_string_escapes_literal_braces() -> None:
     assert format_string.endswith(" in {{group}}")
     assert format_string.format(*result.args[0]) == text1
     assert format_string.format(*result.args[1]) == text2
+
+
+def test_analyzer_analyze_mixed_unicode_normalization() -> None:
+    # NFC and NFD of the same text must not raise RuntimeError.
+    # HFS+/APFS stores filenames as NFD; Linux keeps NFC.
+    nfc = unicodedata.normalize("NFC", "café")
+    nfd = unicodedata.normalize("NFD", "café")
+    result = analyze([nfc, nfd])
+    assert result.to_format_string() == "café"
+    assert result.args[0] == []
+    assert result.args[1] == []


### PR DESCRIPTION
## Summary

Texts from different sources can arrive with inconsistent Unicode normalization forms. macOS HFS+/APFS stores filenames as NFD while Linux keeps NFC, causing `analyze()` to raise `RuntimeError: Internal invariant violated` when the same visually-identical text arrives in mixed forms.

`AnalyzerResult.from_text()` calls `list(text)` to split input into Unicode code points. NFD `"café"` decomposes into 5 code points while NFC `"café"` has 4, so `SequenceMatcher` produces a partial match that breaks the internal invariant check.

This change applies `unicodedata.normalize("NFC", text)` inside `from_text()` so all inputs share the same code-point representation before analysis.

## Changes

- `template_analysis/analyzer.py`: add `import unicodedata`; normalize to NFC in `AnalyzerResult.from_text()`
- `tests/test_analyzer.py`: add `test_analyzer_analyze_mixed_unicode_normalization` covering the NFC/NFD case

## Trade-offs

- Normalization happens silently on every `from_text()` call; callers cannot opt out. This is acceptable because NFC is the recommended canonical form for interchange and the pre-normalization behavior was a crash.
- NFD-only callers will have their input quietly converted. The template and args are still semantically correct.
