### PR TITLE
fix: use Variable.id in to_format_string to produce positional placeholders

### DIFF
--- a/template_analysis/template.py
+++ b/template_analysis/template.py
@@ -12,7 +12,7 @@ class Variable:
     id: int
 
     def to_format_string(self) -> str:
-        return "{}"
+        return f"{{{self.id}}}"
 
 
 @dataclass(frozen=True)

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -23,7 +23,7 @@ def test_analyzer_analyze_2_texts() -> None:
     text2 = "A cat is a good pet"
     result = analyze([text1, text2])
 
-    assert result.to_format_string() == "A {} is a good pet"
+    assert result.to_format_string() == "A {0} is a good pet"
     assert result.args[0] == ["dog"]
     assert result.args[1] == ["cat"]
 
@@ -34,7 +34,7 @@ def test_analyzer_analyze_3_texts() -> None:
     text3 = "A cat is a pretty pet"
     result = analyze([text1, text2, text3])
 
-    assert result.to_format_string() == "A {} is a {} pet"
+    assert result.to_format_string() == "A {0} is a {1} pet"
     assert result.args[0] == ["dog", "good"]
     assert result.args[1] == ["cat", "good"]
     assert result.args[2] == ["cat", "pretty"]
@@ -47,7 +47,7 @@ def test_analyzer_analyze_4_texts() -> None:
     text4 = "A bird is a great pet"
     result = analyze([text1, text2, text3, text4])
 
-    assert result.to_format_string() == "A {} is a {} pet"
+    assert result.to_format_string() == "A {0} is a {1} pet"
     assert result.args[0] == ["dog", "good"]
     assert result.args[1] == ["cat", "good"]
     assert result.args[2] == ["cat", "pretty"]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3,7 +3,12 @@ from template_analysis.template import PlainText, Template, Variable
 
 def test_variable_to_format_string() -> None:
     variable = Variable(0)
-    assert variable.to_format_string() == "{}"
+    assert variable.to_format_string() == "{0}"
+
+
+def test_variable_to_format_string_id_reflected() -> None:
+    assert Variable(1).to_format_string() == "{1}"
+    assert Variable(2).to_format_string() == "{2}"
 
 
 def test_plain_text_to_format_string() -> None:
@@ -13,4 +18,4 @@ def test_plain_text_to_format_string() -> None:
 
 def test_template_to_format_string() -> None:
     template = Template([PlainText("cogito "), Variable(0), PlainText(" sum")])
-    assert template.to_format_string() == "cogito {} sum"
+    assert template.to_format_string() == "cogito {0} sum"


### PR DESCRIPTION
## Summary

`Variable` holds an `id: int` field that `from_symbol_template()` populates with a sequential 0-based index, but `to_format_string()` always returned the anonymous `"{}"` placeholder, silently ignoring the stored index.

Callers who inspect `variable.id` reasonably expect it to appear in the format string. This mismatch between the stored data and the output makes the intent of `id` opaque.

This change returns `f"{{{self.id}}}"` so the format string becomes `"{0}"`, `"{1}"`, etc. — positional placeholders that reflect the index already assigned during template extraction.

## Changes

- `template_analysis/template.py`: `Variable.to_format_string()` now returns `f"{{{self.id}}}"`
- `tests/test_template.py`: update assertions to expect `"{0}"` and add a test verifying different `id` values produce different placeholders
- `tests/test_analyzer.py`: update `to_format_string()` assertions across all multi-variable tests

## Trade-offs

- This is a behavior change to `to_format_string()` output. Callers that compare the raw format string literally will need to update expectations. `str.format(*args)` call patterns are unaffected since `"{0}"` and `"{}"` behave identically with positional arguments.
- Anonymous `{}` and positional `{0}` cannot be mixed in the same format string. Since `to_format_string()` now produces only positional placeholders, any caller mixing the two forms would see a `ValueError`. Existing usage only calls `format()` with positional args, so this is not a concern in practice.
