### PR TITLE
fix: escape literal braces in format strings

### DIFF
--- a/template_analysis/template.py
+++ b/template_analysis/template.py
@@ -22,7 +22,7 @@ class PlainText:
     value: str
 
     def to_format_string(self) -> str:
-        return self.value
+        return self.value.replace("{", "{{").replace("}", "}}")
 
 
 # A part of a template is either a plain text chunk or a variable.

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -79,6 +79,19 @@ def test_analyzer_analyze_long_texts_autojunk_disabled() -> None:
     text2 = prefix + "cat"
     result = analyze([text1, text2])
 
-    assert result.to_format_string() == prefix + "{}"
+    assert result.to_format_string() == prefix + "{0}"
     assert result.args[0] == ["dog"]
     assert result.args[1] == ["cat"]
+
+
+def test_analyzer_to_format_string_escapes_literal_braces() -> None:
+    text1 = "{name} is a dog in {group}"
+    text2 = "{name} is a cat in {group}"
+    result = analyze([text1, text2])
+
+    format_string = result.to_format_string()
+
+    assert format_string.startswith("{{name}} is a ")
+    assert format_string.endswith(" in {{group}}")
+    assert format_string.format(*result.args[0]) == text1
+    assert format_string.format(*result.args[1]) == text2

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -31,7 +31,7 @@ def test_analyzer_analyze_2_texts() -> None:
 def test_analyzer_analyze_2_texts_with_empty_variable() -> None:
     result = analyze(["axb", "ab"])
 
-    assert result.to_format_string() == "a{}b"
+    assert result.to_format_string() == "a{0}b"
     assert result.args[0] == ["x"]
     assert result.args[1] == [""]
 
@@ -39,7 +39,7 @@ def test_analyzer_analyze_2_texts_with_empty_variable() -> None:
 def test_analyzer_analyze_2_texts_with_empty_variable_first() -> None:
     result = analyze(["ab", "axb"])
 
-    assert result.to_format_string() == "a{}b"
+    assert result.to_format_string() == "a{0}b"
     assert result.args[0] == [""]
     assert result.args[1] == ["x"]
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -37,5 +37,5 @@ def test_public_return_type_imports_resolve() -> None:
     assert symbol_string == [symbol, "x"]
     assert chunks == ["dog"]
     assert table.lookup("cat") == "cat"
-    assert template.to_format_string() == "A {}"
+    assert template.to_format_string() == "A {0}"
     assert template_part.to_format_string() == "part"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -16,6 +16,27 @@ def test_plain_text_to_format_string() -> None:
     assert text.to_format_string() == "dog"
 
 
+def test_plain_text_to_format_string_escapes_literal_braces() -> None:
+    text = PlainText("{name} -> {value}")
+    assert text.to_format_string() == "{{name}} -> {{value}}"
+
+
 def test_template_to_format_string() -> None:
     template = Template([PlainText("cogito "), Variable(0), PlainText(" sum")])
     assert template.to_format_string() == "cogito {0} sum"
+
+
+def test_template_to_format_string_preserves_literal_braces() -> None:
+    template = Template(
+        [
+            PlainText("{name} is a "),
+            Variable(0),
+            PlainText(" in {group}"),
+        ],
+    )
+
+    format_string = template.to_format_string()
+
+    assert format_string.startswith("{{name}} is a ")
+    assert format_string.endswith(" in {{group}}")
+    assert format_string.format("dog") == "{name} is a dog in {group}"


### PR DESCRIPTION
## Summary
- escape literal braces in plain text chunks when generating Python format strings
- preserve variable placeholders while keeping fixed `{` and `}` characters literal
- add regression coverage for direct template formatting and analyzer round-trips

## Verification
- `uv sync`
- `uv run pytest tests/test_template.py tests/test_analyzer.py -q`
- `uv run ruff format --check template_analysis/template.py tests/test_template.py tests/test_analyzer.py`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv run ruff check .`
- `uv build`
- `git diff --check`
