### PR TITLE
fix: make sentinel dependency and advance() invariant explicit

### DIFF
--- a/template_analysis/analyzer.py
+++ b/template_analysis/analyzer.py
@@ -153,12 +153,18 @@ class Analyzer:
         blocks = matcher.get_matching_blocks()
         # SequenceMatcher guarantees a sentinel (len(seq1), len(seq2), 0) that
         # drives tail content through advance() to complete both analyzers.
-        sentinel = blocks[-1]
-        assert blocks and (sentinel.a, sentinel.b, sentinel.size) == (
+        sentinel = blocks[-1] if blocks else None
+        if sentinel is None or (sentinel.a, sentinel.b, sentinel.size) != (
             len(seq1),
             len(seq2),
             0,
-        )
+        ):
+            msg = (
+                "get_matching_blocks() must end with the sentinel "
+                "(len(seq1), len(seq2), 0); tail content would be dropped "
+                "without it."
+            )
+            raise RuntimeError(msg)
         analyzer_a = cls.create(seq1)
         analyzer_b = cls.create(seq2)
 

--- a/template_analysis/analyzer.py
+++ b/template_analysis/analyzer.py
@@ -151,6 +151,14 @@ class Analyzer:
     ) -> tuple[Analyzer, Analyzer]:
         matcher = difflib.SequenceMatcher(None, seq1, seq2, autojunk=False)
         blocks = matcher.get_matching_blocks()
+        # SequenceMatcher guarantees a sentinel (len(seq1), len(seq2), 0) that
+        # drives tail content through advance() to complete both analyzers.
+        sentinel = blocks[-1]
+        assert blocks and (sentinel.a, sentinel.b, sentinel.size) == (
+            len(seq1),
+            len(seq2),
+            0,
+        )
         analyzer_a = cls.create(seq1)
         analyzer_b = cls.create(seq2)
 


### PR DESCRIPTION
## Summary

`analyze_two_symbol_strings` relied implicitly on
`difflib.SequenceMatcher.get_matching_blocks()` always appending a sentinel
block `(len(seq1), len(seq2), 0)` to flush any tail content through
`advance()`. This dependency was undocumented and invisible to readers.

`advance()` called `append_unique()` which advances `self.pos` by exactly
the gap size in one pass, so the `while` loop always ran at most once — but
looked as though multiple iterations might be needed.

## Changes

- Add an assertion after `get_matching_blocks()` that verifies the sentinel
  is present (documents the invariant; catches engines that omit it).
- Change `while` → `if` in `advance()` to make the single-iteration
  invariant explicit.

## Verification

- All 11 existing tests pass (`uv run poe test`).
- Lint and type checks pass (`uv run poe check`).
- No new findings from `vulture` (two pre-existing low-confidence hits in
  unrelated files).

## Trade-offs

The assertion fires if the code is ever called with a non-`SequenceMatcher`
diff engine that does not guarantee the sentinel. This is the intended
behavior: fail loudly rather than silently drop tail tokens.