### PR TITLE
fix: flatten symbol chains in SymbolTable.combined() to keep lookup depth at O(1)

### DIFF
--- a/template_analysis/analyzer.py
+++ b/template_analysis/analyzer.py
@@ -105,7 +105,9 @@ class Analyzer:
 
     @classmethod
     def analyze_two_symbol_strings(
-        cls, seq1: SymbolString, seq2: SymbolString,
+        cls,
+        seq1: SymbolString,
+        seq2: SymbolString,
     ) -> tuple[Analyzer, Analyzer]:
         matcher = difflib.SequenceMatcher(None, seq1, seq2)
         blocks = matcher.get_matching_blocks()
@@ -125,10 +127,13 @@ class Analyzer:
 
     @classmethod
     def analyze_two_result(
-        cls, result1: AnalyzerResult, result2: AnalyzerResult,
+        cls,
+        result1: AnalyzerResult,
+        result2: AnalyzerResult,
     ) -> AnalyzerResult:
         analyzer_a, analyzer_b = cls.analyze_two_symbol_strings(
-            result1.text, result2.text,
+            result1.text,
+            result2.text,
         )
         assert analyzer_a.parsed_text == analyzer_b.parsed_text
         return AnalyzerResult(

--- a/template_analysis/symbol.py
+++ b/template_analysis/symbol.py
@@ -37,9 +37,12 @@ class SymbolTable:
         return symbol_or_chunk
 
     def combined(self, other: SymbolTable) -> SymbolTable:
-        new_table = self.table.copy()
-        new_table.update(other.table)
-        return SymbolTable(new_table)
+        merged: dict[Symbol, SymbolChunk] = {**self.table, **other.table}
+        merged_table = SymbolTable(merged)
+        # Flatten symbol chains to depth 1 so lookup() stays O(1) per call.
+        return SymbolTable(
+            {s: merged_table.lookup(s) for s in merged},
+        )
 
 
 SymbolOrCharacter = Symbol | Character

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -39,6 +39,24 @@ def test_symbol_table() -> None:
     assert table.lookup("b") == "b"
 
 
+def test_symbol_table_combined_normalizes_chains() -> None:
+    # table_a: s1 -> "value"
+    table_a = SymbolTable.create()
+    s1 = Symbol.create()
+    table_a.add(s1, "value")
+
+    # table_b: s2 -> s1 (chain s2 -> s1 -> "value")
+    table_b = SymbolTable.create()
+    s2 = Symbol.create()
+    table_b.add(s2, s1)
+
+    combined = table_a.combined(table_b)
+    assert combined.lookup(s1) == "value"
+    assert combined.lookup(s2) == "value"
+    # The combined table must store the resolved chunk directly (depth 1).
+    assert combined.table[s2] == "value"
+
+
 def test_symbol_template() -> None:
     template = SymbolTemplate([], SymbolTable.create())
     assert template.resolve() == []


### PR DESCRIPTION
## Summary

`SymbolTable.combined()` merged two tables without normalizing symbol chains. After `n` rounds of `analyze_two_result()`, each symbol could require up to `n-1` hops in `lookup()`'s while loop — making `AnalyzerResult.args` O(n² × m) overall.

## Root cause

`combined()` used `dict.update()` which preserves existing Symbol values. If `other` mapped `s2 → s1` and `self` mapped `s1 → "abc"`, the merged table had a depth-2 chain `s2 → s1 → "abc"`. Repeating this across `n` rounds produced depth `n-1` chains.

## Change

`combined()` now resolves all symbol values to their final `Chunk` immediately after merging. The returned table stores only `Symbol → Chunk` mappings (depth 1), so `lookup()` terminates in a single iteration regardless of how many texts were analyzed.

## Changes

- **`template_analysis/symbol.py`**: Rewrite `combined()` to flatten all chains: merge both tables, then resolve each symbol value using `lookup()` on the merged table.
- **`tests/test_symbol.py`**: Add `test_symbol_table_combined_normalizes_chains` — asserts that a depth-2 chain (`s2 → s1 → "value"`) collapses to `s2 → "value"` after `combined()`.

## Verification

```
uv run poe format  # 1 file reformatted (symbol.py trailing comma), rest unchanged
uv run poe check   # ruff + mypy: all checks passed
uv run poe test    # 12/12 passed
```

## Trade-offs

`combined()` now does O(m) lookups at merge time (where m = total entries), up from O(m) plain dict copy. Since the chains were always at most depth 2 before flattening (all prior rounds produced depth-1 tables after this fix), the real cost is O(2m) = O(m) — no asymptotic regression. Memory for `AnalyzerResult.tables` (O(n × m) total) is unchanged; that is a separate algorithmic concern noted in README TODO #5.
