### PR TITLE
ci: add test job before deploy in pypi-publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -11,7 +11,33 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.14"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint
+        run: uv run poe check
+
+      - name: Test
+        run: uv run poe test
+
   deploy:
+    needs: [test]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

The `pypi-publish.yml` deploy job had no test execution step. When a release
was created, packages were published to PyPI without any quality gate — bugs or
regressions introduced after the last `main` push could reach downstream users.

## Change

Add a `test` job (lint + unit tests using `uv run poe check` and `uv run poe test`)
that must pass before the `deploy` job runs. The `deploy` job now declares
`needs: [test]`, so the publish step is blocked until tests pass.

Approach: structural — a separate job gate keeps the responsibility clear and
prevents the deploy job from growing too large.

## Verification

- `uv run poe check` (ruff + mypy): all checks passed
- `uv run poe test`: 11/11 tests passed
