### PR TITLE
ci: add SLSA provenance attestation to deploy job

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -58,6 +60,12 @@ jobs:
 
       - name: Build
         run: uv build
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        if: github.event_name == 'release'
+        with:
+          subject-path: dist/*
 
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
## Summary

The `pypi-publish.yml` deploy job published packages to PyPI without attaching
any build provenance. Downstream users had no cryptographic way to verify that
a package was built by the expected GitHub Actions workflow.

## Change

Add an `actions/attest-build-provenance` step (pinned to SHA
`e8998f949152b193b063cb0ec769d69d929409be`, v2.4.0) after the `Build` step.
The step only runs on `release` events so PR builds are unaffected.

The deploy job's permissions are extended with `id-token: write` and
`attestations: write`, which are required by the attestation action.

## Stacking note

This PR is stacked on top of #378 (add test job). It can be rebased onto
`main` once #378 is merged.

## Verification

- `uv run poe check` (ruff + mypy): all checks passed
- `uv run poe test`: 11/11 tests passed
