### PR TITLE
ci: migrate PyPI publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -37,13 +38,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `user: __token__` and `password:` fields from PyPI and Test PyPI publish steps to enable Trusted Publishing (OIDC)
- Add `id-token: write` permission to the deploy job so GitHub Actions can obtain an OIDC token
- `pypa/gh-action-pypi-publish` automatically switches to OIDC when no credentials are provided

## Motivation

Long-lived API tokens (`PYPI_API_TOKEN`, `TEST_PYPI_API_TOKEN`) are a persistent security risk — if leaked, an attacker can publish arbitrary packages at any time. PyPI's Trusted Publishing eliminates long-lived secrets by using short-lived OIDC tokens tied to a specific repository and workflow.

## Prerequisites

Before merging, configure Trusted Publishers on each index:

- **PyPI**: `https://pypi.org/manage/project/<package>/settings/publishing/`
  - Publisher: GitHub Actions, owner: `kitsuyui`, repo: `python-template-analysis`, workflow: `pypi-publish.yml`, environment: (leave blank)
- **Test PyPI**: same settings on `https://test.pypi.org/`

## Verification

- Workflow YAML is valid (no `user:`/`password:` references remain)
- `id-token: write` permission is present at job level
