### PR TITLE
Add max_texts parameter to guard against unbounded memory use in analyze_texts

### DIFF
--- a/template_analysis/analyzer.py
+++ b/template_analysis/analyzer.py
@@ -175,21 +175,26 @@ class Analyzer:
         return analyzer_a, analyzer_b
 
     @classmethod
-    def analyze(cls, texts: list[str]) -> AnalyzerResult:
+    def analyze(
+        cls,
+        texts: list[str],
+        max_texts: int | None = None,
+    ) -> AnalyzerResult:
         """Analyze a list of texts and extract a common template.
 
         Args:
             texts: Non-empty list of strings to analyze.
+            max_texts: Optional upper bound on the number of texts to analyze.
 
         Returns:
             An AnalyzerResult containing the extracted template and per-text
             argument lists.
 
         Raises:
-            ValueError: If texts is empty.
+            ValueError: If texts is empty or exceeds max_texts.
 
         """
-        return cls._analyze_texts(texts)
+        return cls._analyze_texts(texts, max_texts=max_texts)
 
     @classmethod
     def analyze_two_result(
@@ -222,12 +227,26 @@ class Analyzer:
             ],
         )
 
+    @staticmethod
+    def _assert_max_texts(n: int, max_texts: int | None) -> None:
+        if max_texts is not None and n > max_texts:
+            raise ValueError(
+                f"Too many texts: got {n}, max_texts={max_texts}. "
+                "analyze_texts holds O(N) SymbolTable entries in memory.",
+            )
+
     @classmethod
-    def _analyze_texts(cls, texts: list[str]) -> AnalyzerResult:
+    def _analyze_texts(
+        cls,
+        texts: list[str],
+        max_texts: int | None = None,
+    ) -> AnalyzerResult:
         texts = texts[:]
 
         if not texts:
             raise ValueError("texts are empty.")
+
+        cls._assert_max_texts(len(texts), max_texts)
 
         text = texts.pop(0)
         acc = AnalyzerResult._from_text(text)

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -108,3 +108,21 @@ def test_analyzer_analyze_mixed_unicode_normalization() -> None:
     assert result.to_format_string() == "café"
     assert result.args[0] == []
     assert result.args[1] == []
+
+
+def test_analyzer_max_texts_limit() -> None:
+    texts = ["A dog is a good pet", "A cat is a good pet", "A bird is a good pet"]
+    with pytest.raises(ValueError, match="Too many texts"):
+        analyze(texts, max_texts=2)
+
+
+def test_analyzer_max_texts_at_limit() -> None:
+    texts = ["A dog is a good pet", "A cat is a good pet"]
+    result = analyze(texts, max_texts=2)
+    assert result.to_format_string() == "A {0} is a good pet"
+
+
+def test_analyzer_max_texts_none() -> None:
+    texts = ["A dog is a good pet", "A cat is a good pet", "A bird is a good pet"]
+    result = analyze(texts, max_texts=None)
+    assert len(result.args) == 3


### PR DESCRIPTION
## Summary

`analyze_texts` accumulates one `SymbolTable` per input text, so memory grows
O(N) with no way for callers to enforce a limit. Callers who pass large `texts`
lists without knowing this constraint risk OOM.

Add an optional `max_texts` parameter (default `None`, preserving existing
behavior). When set, `ValueError` is raised before processing starts if the
input exceeds the limit.

## Changes

- `template_analysis/analyzer.py`: add `max_texts: int | None = None` to
  `Analyzer.analyze` and `Analyzer.analyze_texts`; extract `_assert_max_texts`
  helper to keep McCabe complexity within the project lint limit
- `tests/test_analyzer.py`: add tests for limit enforcement, at-limit behavior,
  and `max_texts=None` passthrough

## Test plan

- [x] `test_analyzer_max_texts_limit`: raises `ValueError` when input exceeds limit
- [x] `test_analyzer_max_texts_at_limit`: passes when input is exactly at limit
- [x] `test_analyzer_max_texts_none`: no limit when `max_texts=None`
- [x] All 14 tests pass