### PR TITLE
docs: fix README example and update development status to Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ result = analyze([
     "A cat is a pretty pet",
     "A bird is a great pet",
 ])
-result.to_format_string()  # => "A {} is a {} pet"
+result.to_format_string()  # => "A {0} is a {1} pet"
 result.args[0]  # => ["dog", "good"]
 result.args[1]  # => ["cat", "good"]
 result.args[2]  # => ["cat", "pretty"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     {name = "Yui KITSU", email = "kitsuyui+github@kitsuyui.com"}
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary

`Variable.to_format_string()` now returns positional placeholders (`{0}`, `{1}`) following the change in #373, but the README example still showed the old unnumbered form (`{}`). This PR corrects the example and advances the development status classifier.

## Changes

- `README.md`: Update usage example comment from `"A {} is a {} pet"` to `"A {0} is a {1} pet"` to match actual `to_format_string()` output.
- `pyproject.toml`: Promote `Development Status :: 3 - Alpha` to `Development Status :: 4 - Beta`. The library has had 8+ PyPI releases and a stable public API; the Alpha label no longer reflects its maturity.

## Dependency

This PR is stacked on #373 (`fix/audit-variable-id-unused-in-output-001`). Merge #373 first, then this PR.

## Verification

- `uv run poe format` — clean
- `uv run poe check` (ruff + mypy) — clean
- `uv run poe test` — 12 tests pass
- `uvx vulture template_analysis tests --min-confidence 100` — 0 findings
