### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,34 @@ result.args[3]  # => ["bird", "great"]
 ![4-template-deriving-2](https://user-images.githubusercontent.com/2596972/73120670-7c485600-3fb4-11ea-9eba-01aaafd08e4e.png)
 ![4-automated-scraping](https://user-images.githubusercontent.com/2596972/73120671-7c485600-3fb4-11ea-8ed6-56b93ee99b3a.png)
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
+uv run poe test
+```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 ## License
 
 The 3-Clause BSD License. See also LICENSE file.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` so the same checks that run in CI also run locally on pre-commit and pre-push, surfacing problems before they reach GitHub Actions.
- CI workflows are left completely unchanged — Actions remain free for public repos, and the hooks simply bring that feedback earlier on each contributor's machine.

## Changes

- **`lefthook.yml`**: defines two hook stages:
  - `pre-commit` — runs `uv run poe check` (ruff + mypy)
  - `pre-push` — runs `uv run poe check` and `uv run poe test`
  Both stages unset `GIT_*` environment variables first so nested/sibling repositories are not affected.
- **`README.md`**: adds a `## Development` section (inserted before `## License`) explaining how to install dependencies, install the hooks with `lefthook install`, and run the checks manually.

## Verification

- `uv run poe check` passes locally (ruff: all checks passed; mypy: no issues in 5 source files).
- `uv run poe test` passes locally (21 passed).
- The pre-commit hook fired during the commit and passed.
- The pre-push hook fired during `git push` (both `check` and `test` jobs) and passed.

## Notes

- Requires `lefthook` on `PATH` to use the hooks (`lefthook install` is a one-time setup step).
- No CI workflow was added, modified, or removed.
