### PR TITLE
fix: add coverage fail_under threshold to .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [report]
+fail_under = 70
 exclude_lines =
     @overload
     pragma: no cover


### PR DESCRIPTION
## Summary

Add `fail_under = 70` to `.coveragerc [report]` so that `pytest-cov` exits non-zero when total coverage drops below 70%.

**Before:** coverage.xml is generated and reported by octocov as a PR comment, but CI does not fail when coverage regresses — octocov operates as a passive dashboard, not a quality gate.

**After:** `uv run poe coverage-xml` (the CI Coverage step) fails when coverage falls below 70%, giving CI an active quality gate for coverage regressions.

## Changes

- `.coveragerc`: Add `fail_under = 70` under `[report]`.

## Verification

- `ruff check template_analysis` — clean
- The change is a single config line; no logic is affected.

## Notes

The 70% threshold is a conservative starting point. It should be tuned upward based on the current measured coverage once CI has run.