### PR TITLE
Add changelog and release notes link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## Unreleased
+
+- Added a coverage threshold so regressions fail CI before release.
+- Added lefthook documentation for running project checks locally.
+- Normalized input text to NFC before analysis.
+- Escaped literal braces in generated format strings.
+- Migrated PyPI publishing to Trusted Publishing with OIDC.
+
+## [v0.0.8] - 2025-01-31
+
+- Migrated the project from Poetry to uv.
+- Refreshed development dependencies and release tooling.
+
+## [v0.0.7] - 2024-10-15
+
+- Added Python 3.13 support.
+- Dropped Python 3.8 support.
+- Added gitignore-in generated `.gitignore` maintenance.
+
+## [v0.0.6] - 2023-10-06
+
+- Added Python 3.12 support.
+- Fixed a GitHub Actions workflow trigger.
+- Refreshed development dependencies.
+
+## [v0.0.5] - 2023-07-20
+
+- Added typo checking.
+- Refreshed development dependencies and lock files.
+
+## [v0.0.4] - 2023-03-21
+
+- Added Python 3.11 support.
+- Refactored the implementation.
+- Updated CI.
+
+## [v0.0.3] - 2023-01-09
+
+- Enhanced CI.
+
+## [v0.0.2] - 2022-08-08
+
+- Added support for analyzing multiple texts.
+
+## [v0.0.1] - 2022-08-07
+
+- Initial release.
+
+[v0.0.8]: https://github.com/kitsuyui/python-template-analysis/releases/tag/v0.0.8
+[v0.0.7]: https://github.com/kitsuyui/python-template-analysis/releases/tag/v0.0.7
+[v0.0.6]: https://github.com/kitsuyui/python-template-analysis/releases/tag/v0.0.6
+[v0.0.5]: https://github.com/kitsuyui/python-template-analysis/releases/tag/v0.0.5
+[v0.0.4]: https://github.com/kitsuyui/python-template-analysis/releases/tag/v0.0.4
+[v0.0.3]: https://github.com/kitsuyui/python-template-analysis/releases/tag/v0.0.3
+[v0.0.2]: https://github.com/kitsuyui/python-template-analysis/releases/tag/v0.0.2
+[v0.0.1]: https://github.com/kitsuyui/python-template-analysis/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ uv run poe test
 CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
 feedback earlier on your machine.
 
+## Release notes
+
+See [CHANGELOG.md](CHANGELOG.md) for release history and upgrade notes.
+
 ## License
 
 The 3-Clause BSD License. See also LICENSE file.


### PR DESCRIPTION
Summary:
- add a CHANGELOG.md with an Unreleased section and historical summaries for v0.0.1 through v0.0.8
- link the changelog from README.md so release history is easy to find

Checks:
- uv run poe check
- uv run poe test
- uv run poe coverage-xml
- uv build
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
- typos README.md CHANGELOG.md
- collateral check: clean

Notes:
- uv build still reports existing setuptools license deprecation warnings; this PR does not change package metadata.
