### PR TITLE
ci: add pip-audit job to scan dependencies for vulnerabilities

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -63,3 +63,21 @@ jobs:
 
       - name: Coverage
         run: uv run poe coverage-xml
+
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Export dependencies
+        run: uv export --format requirements-txt --all-groups --no-hashes | grep -v '^-e ' > /tmp/requirements.txt
+
+      - name: Audit dependencies
+        run: uvx pip-audit --requirement /tmp/requirements.txt


### PR DESCRIPTION
## Summary

The CI pipeline has no vulnerability scan step. This adds a `pip-audit` job to `python-test.yml` that audits all dev dependencies (exported from `uv.lock`) against the PyPI Advisory Database (OSV).

## Changes

- `.github/workflows/python-test.yml`: new `pip-audit` job that:
  - exports the full dev dependency set via `uv export` (excluding the editable project install)
  - runs `uvx pip-audit --requirement` against the exported list
  - uses the same pinned action digests already in the workflow

## Notes

- Runs independently of the Python-version matrix -- one scan covers all versions
- `uvx pip-audit` runs in an isolated environment; no change to `pyproject.toml` or `uv.lock`
- Runtime dependencies are empty (`dependencies = []`); dev deps (pytest, mypy, ruff, etc.) are the scan target
